### PR TITLE
Don't specify a line-ending encoding explicitly

### DIFF
--- a/helm-posframe.el
+++ b/helm-posframe.el
@@ -169,7 +169,7 @@ In this advice function, `burn-buffer' will be temp redefine as
 (provide 'helm-posframe)
 
 ;; Local Variables:
-;; coding: utf-8-unix
+;; coding: utf-8
 ;; End:
 
 ;;; helm-posframe.el ends here


### PR DESCRIPTION
Changed `utf-8-unix` encoding to `utf-8`.

By specifying an explicit line encoding, `hack-local-variables` will throw a `Local variables entry is missing the suffix` error on Windows, when a package is cloned via `git` without `autocrlf` enabled.

More specifically: when installing packages 1) with [straight.el](https://github.com/raxod502/straight.el#the-recipe-format), 2) on Windows, 3) that have hard-coded a utf-8-unix encoding in its file local variables, we get issues like this: https://github.com/hlissner/doom-emacs/issues/2637, https://github.com/hlissner/doom-emacs/issues/2548, and https://github.com/raxod502/straight.el/issues/346 