### PR TITLE
include parameter for helm-posframe-border-width

### DIFF
--- a/helm-posframe.el
+++ b/helm-posframe.el
@@ -100,6 +100,12 @@ When nil, Using current frame's font as fallback."
   :group 'helm-posframe
   :type 'string)
 
+(defcustom helm-posframe-border-width 1
+  "The border width used by helm-posframe.
+When 0, no border is shown."
+  :group 'helm-posframe
+  :type 'number)
+
 (defcustom helm-posframe-parameters nil
   "The frame parameters used by helm-posframe."
   :group 'helm-posframe
@@ -121,6 +127,7 @@ Argument BUFFER."
          :poshandler helm-posframe-poshandler
          :font helm-posframe-font
          :override-parameters helm-posframe-parameters
+	 :internal-border-width helm-posframe-border-width
          :respect-header-line t
          (funcall helm-posframe-size-function)))
 


### PR DESCRIPTION
Add a parameter to set border width as in `ivy-posframe`. I assume it's possible to change this via `helm-posframe-parameters` but maybe easier to be consistent between packages.